### PR TITLE
新增 dusk 測試：E-mail 已經有人註冊了

### DIFF
--- a/tests/Browser/Auth/AuthTest.php
+++ b/tests/Browser/Auth/AuthTest.php
@@ -82,7 +82,7 @@ class AuthTest extends DuskTestCase
     }
 
     /**
-     * 異常註冊流程：Email 已經有人註冊了
+     * 異常註冊流程：E-mail 已經有人註冊了
      *
      * @group r4
      */
@@ -99,6 +99,27 @@ class AuthTest extends DuskTestCase
                     ->type('password_confirmation', 'password')
                     ->press('Register')
                     ->assertSee('The email has already been taken.');
+        });
+    }
+
+    /**
+     * 異常註冊流程：密碼和密碼確認欄位輸入不一樣
+     *
+     * @group r5
+     */
+    public function testFieldPasswordAndConfirmationDifferent()
+    {
+        $this->browse(function (Browser $browser) {
+            $user = factory(User::class)->make();
+
+            $browser->visit('/register')
+                    // 輸入註冊資料
+                    ->type('name', $user->name)
+                    ->type('email', $user->email)
+                    ->type('password', '12345678')
+                    ->type('password_confirmation', '87654321')
+                    ->press('Register')
+                    ->assertSee('The password confirmation does not match.');
         });
     }
 }

--- a/tests/Browser/Auth/AuthTest.php
+++ b/tests/Browser/Auth/AuthTest.php
@@ -51,6 +51,9 @@ class AuthTest extends DuskTestCase
             $this->assertEquals($newUser->name, $user->name);
             $this->assertEquals($newUser->email, $user->email);
             $this->assertTrue(Hash::check($newUser->password, $user->password));
+
+            // 登出，確保不會影響其他測試執行
+            $browser->clickLink($newUser->name)->clickLink('Logout');
         });
     }
 
@@ -75,6 +78,27 @@ class AuthTest extends DuskTestCase
                     ->type('password_confirmation', $newUser->password)
                     ->press('Register')
                     ->assertSee('The password must be at least 8 characters.');
+        });
+    }
+
+    /**
+     * 異常註冊流程：Email 已經有人註冊了
+     *
+     * @group r4
+     */
+    public function testEmailHasBeenRegistered()
+    {
+        $this->browse(function (Browser $browser) {
+            $user = factory(User::class)->create();
+
+            $browser->visit('/register')
+                    // 輸入註冊資料
+                    ->type('name', $user->name)
+                    ->type('email', $user->email)
+                    ->type('password', 'password')
+                    ->type('password_confirmation', 'password')
+                    ->press('Register')
+                    ->assertSee('The email has already been taken.');
         });
     }
 }

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -44,15 +44,15 @@ abstract class DuskTestCase extends BaseTestCase
     }
 
     /**
-     * 測試執行後清空資料
+     * 測試執行前清空資料
      *
      * 因爲 trait RefreshDatabase 不一定會正確執行
      *
      * @return void
      */
-    protected function tearDown(): void
+    protected function setUp(): void
     {
+        parent::setUp();
 	Artisan::call('migrate:fresh');
-        parent::tearDown();
     }
 }


### PR DESCRIPTION
- 另外DuskTestCase tearDown() 的內容改在 setUp() 執行
確保每次測試的開頭都是空的資料

- 正常註冊流程 執行完會點選 Logout，確保不會影響其他測試
在 setUp() 設定 session()->flush() 清空 session 並沒有相同效果